### PR TITLE
Fix debug line matching.

### DIFF
--- a/fixtures/test_symr.txt
+++ b/fixtures/test_symr.txt
@@ -11643,11 +11643,11 @@ _DATA__TtC12Rollbar_Demo11AppDelegate (in test.dwarf) + 0
 
 full type metadata for AppDelegate (in test.dwarf) + 0
 
-type metadata for AppDelegate (in test.dwarf) + 0
 OBJC_CLASS_$__TtC12Rollbar_Demo11AppDelegate (in test.dwarf) + 0
+type metadata for AppDelegate (in test.dwarf) + 0
 
-type metadata for AppDelegate (in test.dwarf) + 0
 OBJC_CLASS_$__TtC12Rollbar_Demo11AppDelegate (in test.dwarf) + 0
+type metadata for AppDelegate (in test.dwarf) + 0
 
 OBJC_METACLASS_$_RollbarAppLanguageUtil (in test.dwarf) + 0
 


### PR DESCRIPTION
Matching debug lines must be done considering the interval between the previous entry and the current, and not an exact address match. So this commit updates the match logic to account for this.

Story: [ch126542]